### PR TITLE
chore: set version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "farm-game-react",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "farm-game-react",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@rainbow-me/rainbowkit": "^2.2.8",
         "@sentry/react": "^10.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "farm-game-react",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig(({ mode }) => {
   const plugins: PluginOption[] = [react()];
   if (mode === 'analyze') {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { visualizer } = require('rollup-plugin-visualizer') as { visualizer: (opts?: any) => PluginOption }
       plugins.push(visualizer({ filename: 'bundle-stats.html', gzipSize: true, brotliSize: true }) as PluginOption)
     } catch {
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => {
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode),
       // Expose app version for Sentry release tagging and diagnostics
-      'import.meta.env.VITE_APP_VERSION': JSON.stringify(process.env.npm_package_version || '0.0.0'),
+      'import.meta.env.VITE_APP_VERSION': JSON.stringify(process.env.npm_package_version || '1.0.0'),
     },
     esbuild: { 
       drop: mode === 'production' ? ['console', 'debugger'] : [],


### PR DESCRIPTION
## Summary
- set package version to 1.0.0
- expose app version in Vite config and clean up lint rule
- sync package-lock

## Testing
- `npm test` (fails: Cannot use 'import.meta' outside a module)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a230261044832fba0782e9235fc5fe